### PR TITLE
using updated cryptonator api url

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -184,7 +184,7 @@ function collectUsersHashrate(chartName, settings) {
 }
 
 function getCoinPrice(callback) {
-    apiInterfaces.jsonHttpRequest('www.cryptonator.com', 443, '', function(error, response) {
+    apiInterfaces.jsonHttpRequest('api.cryptonator.com', 443, '', function(error, response) {
         callback(response.error ? response.error : error, response.success ? +response.ticker.price : null);
     }, '/api/ticker/' + config.symbol.toLowerCase() + '-usd');
 }

--- a/website-example/pages/home.html
+++ b/website-example/pages/home.html
@@ -402,7 +402,7 @@
         for (var i = 0; i < cryptonatorWidget.length; i++){
             (function(i){
             	cryptonatorWidget[i] = cryptonatorWidget[i].replace('{symbol}', lastStats.config.symbol.toLowerCase());
-                xhrMarketGets[cryptonatorWidget[i]] = $.get('https://www.cryptonator.com/api/ticker/' + cryptonatorWidget[i], function(data){
+                xhrMarketGets[cryptonatorWidget[i]] = $.get('https://api.cryptonator.com/api/ticker/' + cryptonatorWidget[i], function(data){
                     if(data.error) {
                         return;
                     }


### PR DESCRIPTION
https://www.cryptonator.com/api

fixes Market's requests. Currently you can get something like:
XMLHttpRequest cannot load https://www.cryptonator.com/api/ticker/xmr-BTC. Redirect from 'https://www.cryptonator.com/api/ticker/xmr-BTC' to 'https://www.cryptonator.com/api/ticker/xmr-BTC' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Proper url is 'api.cryptonator.com' with 'Access-Control-Allow-Origin' header.

proofs:
api: https://www.cryptonator.com/api
cryptonator's widget: https://www.cryptonator.com/ui/js/widget/single_widget.js