### PR TITLE
Added miner id in jobs

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -327,7 +327,8 @@ Miner.prototype = {
         return {
             blob: blob,
             job_id: newJob.id,
-            target: target
+            target: target,
+            id: this.id
         };
     },
     checkBan: function(validShare){


### PR DESCRIPTION
This modification is crucial to make this software working with mining proxies because they rely on the miner id to dispatch jobs and submissions